### PR TITLE
AstronInternalRepository: Fix UnicodeDecodeError for fieldPacker

### DIFF
--- a/direct/src/distributed/AstronInternalRepository.py
+++ b/direct/src/distributed/AstronInternalRepository.py
@@ -522,7 +522,7 @@ class AstronInternalRepository(ConnectionRepository):
             dg.addServerHeader(doId, self.ourChannel, STATESERVER_OBJECT_SET_FIELDS)
             dg.addUint32(doId)
             dg.addUint16(fieldCount)
-            dg.appendData(fieldPacker.getString())
+            dg.appendData(fieldPacker.getBytes())
             self.send(dg)
             # Now slide it into the zone we expect to see it in (so it
             # generates onto us with all of the fields in place)


### PR DESCRIPTION
In python3 this is a byte not a string.
credit to  rocketprogrammer for the fix
